### PR TITLE
feat: dashboard com filtros de ano/mês/semana no gráfico

### DIFF
--- a/app/pages/home/home.tsx
+++ b/app/pages/home/home.tsx
@@ -1,51 +1,234 @@
 import type { Route } from "../home/+types/home";
+import { useEffect, useState } from "react";
 import { LineChart } from "@mui/x-charts/LineChart";
 import {
-  ContinuousColorLegend,
-  PiecewiseColorLegend,
-} from "@mui/x-charts/ChartsLegend";
+  Box,
+  MenuItem,
+  Paper,
+  Select,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
 import { LayoutPage } from "~/shared/layouts/layoutPages";
-import { ToolsList } from "~/components/toolsList/toolsList";
-import { ToolsDetails } from "~/components/toolsDetails/toolsDetails";
+import {
+  getDashboardResumo,
+  type IDashboardResumo,
+} from "~/shared/services/api/dashboard/get-resumo";
+import {
+  getDashboardSerie,
+  type TPeriodoGrafico,
+} from "~/shared/services/api/dashboard/get-serie";
+import { getAnosDisponiveis } from "~/shared/services/api/dashboard/get-anos-disponiveis";
 
 import plusPerson from "../../assets/img/ChatGPT Image Apr 8, 2025, 01_34_50 PM.png";
 import lessPerson from "../../assets/img/ChatGPT Image Apr 8, 2025, 01_34_42 PM.png";
-import { Box } from "@mui/material";
 
 export function meta({}: Route.MetaArgs) {
   return [
-    { title: "New React Router App" },
-    { name: "description", content: "Welcome to React Router!" },
+    { title: "Página inicial" },
+    { name: "description", content: "Dashboard financeiro" },
   ];
 }
 
-export default function Home() {
-  const months = [
-    "Jan",
-    "Fev",
-    "Mar",
-    "Abr",
-    "Mai",
-    "Jun",
-    "Jul",
-    "Ago",
-    "Set",
-    "Out",
-    "Nov",
-    "Dez",
-  ];
+const NOMES_MESES = [
+  "Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho",
+  "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro",
+];
 
-  const saldoPorMes = [
-    1000, 1200, 800, 1500, 2000, 1800, 2200, 2500, 2300, 2800, 3000, 3200,
-  ];
+const formatarMoeda = (valor: number) =>
+  new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(valor);
+
+const corPorStatus = (status: string) => {
+  switch (status) {
+    case "Saudável":
+      return "success.main";
+    case "Atenção":
+      return "warning.main";
+    case "Crítico":
+      return "error.main";
+    default:
+      return "text.secondary";
+  }
+};
+
+const formatarPeriodo = (data: Date, periodo: TPeriodoGrafico) => {
+  if (periodo === "ano") {
+    return new Intl.DateTimeFormat("pt-BR", { year: "numeric" }).format(data);
+  }
+
+  if (periodo === "semana") {
+    return new Intl.DateTimeFormat("pt-BR", { day: "2-digit", month: "2-digit" }).format(data);
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", { month: "short", year: "2-digit" }).format(data);
+};
+
+export default function Home() {
+  const [resumo, setResumo] = useState<IDashboardResumo>();
+  const [meses, setMeses] = useState<string[]>([]);
+  const [saldosPorPeriodo, setSaldosPorPeriodo] = useState<number[]>([]);
+  const [periodo, setPeriodo] = useState<TPeriodoGrafico>("mes");
+  const [anoSelecionado, setAnoSelecionado] = useState<number | "">("");
+  const [mesSelecionado, setMesSelecionado] = useState<number | "">("");
+  const [anosDisponiveis, setAnosDisponiveis] = useState<number[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsLoading(true);
+
+    getDashboardResumo(1).then((result) => {
+      setIsLoading(false);
+
+      if (result instanceof Error) {
+        alert(result.message);
+        return;
+      }
+
+      setResumo(result);
+    });
+
+    getAnosDisponiveis(1).then((result) => {
+      if (result instanceof Error) {
+        alert(result.message);
+        return;
+      }
+
+      setAnosDisponiveis(result);
+    });
+  }, []);
+
+  useEffect(() => {
+    getDashboardSerie(1, {
+      periodo,
+      ano: anoSelecionado === "" ? undefined : anoSelecionado,
+      mes: mesSelecionado === "" ? undefined : mesSelecionado,
+    }).then((result) => {
+      if (result instanceof Error) {
+        alert(result.message);
+        return;
+      }
+
+      setMeses(result.map((item) => formatarPeriodo(new Date(item.periodo), periodo)));
+      setSaldosPorPeriodo(result.map((item) => item.saldo));
+    });
+  }, [periodo, anoSelecionado, mesSelecionado]);
+
+  const trocarPeriodo = (novoPeriodo: TPeriodoGrafico | null) => {
+    if (!novoPeriodo) return;
+    setPeriodo(novoPeriodo);
+    setAnoSelecionado("");
+    setMesSelecionado("");
+  };
+
+  const saldoPositivo = (resumo?.saldoAtual ?? 0) >= 0;
 
   return (
-    <LayoutPage titulo="Página inicial">
+    <LayoutPage titulo="Página inicial" isLoading={isLoading}>
+      <Box display="flex" flexWrap="wrap" gap={3} margin="2em">
+        <Paper elevation={4} className="p-4 flex-1" sx={{ minWidth: "16em" }}>
+          <Typography variant="subtitle2" color="text.secondary">
+            Saldo atual
+          </Typography>
+          <Typography variant="h4" color={saldoPositivo ? "success.main" : "error.main"}>
+            {formatarMoeda(resumo?.saldoAtual ?? 0)}
+          </Typography>
+        </Paper>
+
+        <Paper elevation={4} className="p-4 flex-1" sx={{ minWidth: "16em" }}>
+          <Typography variant="subtitle2" color="text.secondary">
+            Saúde financeira
+          </Typography>
+          <Typography variant="h4" color={corPorStatus(resumo?.saudeFinanceiraStatus ?? "")}>
+            {resumo?.saudeFinanceiraStatus ?? "-"}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {resumo ? `${resumo.saudeFinanceiraPercentual}% da receita poupado este mês` : ""}
+          </Typography>
+        </Paper>
+
+        <Paper elevation={4} className="p-4 flex-1" sx={{ minWidth: "16em" }}>
+          <Typography variant="subtitle2" color="text.secondary">
+            Com o que mais gastei este mês
+          </Typography>
+          <Typography variant="h4">
+            {resumo?.maiorCategoriaGasto ?? "Sem dados"}
+          </Typography>
+          {resumo?.maiorCategoriaGasto && (
+            <Typography variant="body2" color="text.secondary">
+              {formatarMoeda(resumo.maiorCategoriaValor)}
+            </Typography>
+          )}
+        </Paper>
+      </Box>
+
       <Box display="flex" justifyContent="space-around" margin="5em" gap={5}>
         <Box flex={1}>
+          <Box display="flex" justifyContent="flex-end" alignItems="center" gap={2} marginBottom={2}>
+            {(periodo === "ano" || periodo === "semana") && (
+              <Select
+                size="small"
+                displayEmpty
+                value={anoSelecionado}
+                onChange={(e) => setAnoSelecionado(e.target.value === "" ? "" : Number(e.target.value))}
+              >
+                <MenuItem value="">{periodo === "ano" ? "Todos os anos" : "Ano"}</MenuItem>
+                {anosDisponiveis.map((ano) => (
+                  <MenuItem key={ano} value={ano}>
+                    {ano}
+                  </MenuItem>
+                ))}
+              </Select>
+            )}
+
+            {periodo === "mes" && (
+              <Select
+                size="small"
+                displayEmpty
+                value={anoSelecionado}
+                onChange={(e) => setAnoSelecionado(e.target.value === "" ? "" : Number(e.target.value))}
+              >
+                <MenuItem value="">Últimos 12 meses</MenuItem>
+                {anosDisponiveis.map((ano) => (
+                  <MenuItem key={ano} value={ano}>
+                    {ano}
+                  </MenuItem>
+                ))}
+              </Select>
+            )}
+
+            {periodo === "semana" && (
+              <Select
+                size="small"
+                displayEmpty
+                disabled={anoSelecionado === ""}
+                value={mesSelecionado}
+                onChange={(e) => setMesSelecionado(e.target.value === "" ? "" : Number(e.target.value))}
+              >
+                <MenuItem value="">Mês</MenuItem>
+                {NOMES_MESES.map((nome, index) => (
+                  <MenuItem key={nome} value={index + 1}>
+                    {nome}
+                  </MenuItem>
+                ))}
+              </Select>
+            )}
+
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={periodo}
+              onChange={(_, novoPeriodo: TPeriodoGrafico | null) => trocarPeriodo(novoPeriodo)}
+            >
+              <ToggleButton value="semana">Semana</ToggleButton>
+              <ToggleButton value="mes">Mês</ToggleButton>
+              <ToggleButton value="ano">Ano</ToggleButton>
+            </ToggleButtonGroup>
+          </Box>
+
           <LineChart
-            xAxis={[{ scaleType: "band", data: months }]}
-            series={[{ data: saldoPorMes }]}
+            xAxis={[{ scaleType: "band", data: meses }]}
+            series={[{ data: saldosPorPeriodo, label: "Saldo" }]}
             height={300}
             margin={{ left: 100, right: 30, top: 30, bottom: 30 }}
             grid={{ vertical: false, horizontal: true }}
@@ -63,7 +246,10 @@ export default function Home() {
           border="1em solid"
           boxShadow="0px 1px 41px 29px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12)"
         >
-          <img src={plusPerson} alt="Saldo positivo" />
+          <img
+            src={saldoPositivo ? plusPerson : lessPerson}
+            alt={saldoPositivo ? "Saldo positivo" : "Saldo negativo"}
+          />
         </Box>
       </Box>
     </LayoutPage>

--- a/app/shared/services/api/dashboard/get-anos-disponiveis.ts
+++ b/app/shared/services/api/dashboard/get-anos-disponiveis.ts
@@ -1,0 +1,20 @@
+import { coreApi } from "../axiosConfig";
+
+export const getAnosDisponiveis = async (codUsuario: number): Promise<number[] | Error> => {
+  try {
+    const urlRelative = `/Dashboard/anos-disponiveis`;
+
+    const { data } = await coreApi.get(urlRelative, { params: { codUsuario } });
+
+    if (data) {
+      return data;
+    }
+
+    return new Error("Erro ao buscar os anos disponíveis.");
+  } catch (error) {
+    console.log(error);
+    return new Error(
+      (error as { message?: string })?.message || "Erro ao buscar os anos disponíveis."
+    );
+  }
+};

--- a/app/shared/services/api/dashboard/get-resumo.ts
+++ b/app/shared/services/api/dashboard/get-resumo.ts
@@ -1,0 +1,28 @@
+import { coreApi } from "../axiosConfig";
+
+export interface IDashboardResumo {
+  saldoAtual: number;
+  maiorCategoriaGasto: string | null;
+  maiorCategoriaValor: number;
+  saudeFinanceiraPercentual: number;
+  saudeFinanceiraStatus: string;
+}
+
+export const getDashboardResumo = async (codUsuario: number): Promise<IDashboardResumo | Error> => {
+  try {
+    const urlRelative = `/Dashboard/resumo`;
+
+    const { data } = await coreApi.get(urlRelative, { params: { codUsuario } });
+
+    if (data) {
+      return data;
+    }
+
+    return new Error("Erro ao buscar o resumo do dashboard.");
+  } catch (error) {
+    console.log(error);
+    return new Error(
+      (error as { message?: string })?.message || "Erro ao buscar o resumo do dashboard."
+    );
+  }
+};

--- a/app/shared/services/api/dashboard/get-serie.ts
+++ b/app/shared/services/api/dashboard/get-serie.ts
@@ -1,0 +1,40 @@
+import { coreApi } from "../axiosConfig";
+
+export type TPeriodoGrafico = "ano" | "mes" | "semana";
+
+export interface ISaldoPeriodo {
+  periodo: Date;
+  receita: number;
+  despesa: number;
+  saldo: number;
+}
+
+export interface IFiltroSerie {
+  periodo: TPeriodoGrafico;
+  ano?: number;
+  mes?: number;
+}
+
+export const getDashboardSerie = async (
+  codUsuario: number,
+  filtro: IFiltroSerie
+): Promise<ISaldoPeriodo[] | Error> => {
+  try {
+    const urlRelative = `/Dashboard/serie`;
+
+    const { data } = await coreApi.get(urlRelative, {
+      params: { codUsuario, periodo: filtro.periodo, ano: filtro.ano, mes: filtro.mes },
+    });
+
+    if (data) {
+      return data;
+    }
+
+    return new Error("Erro ao buscar a série do gráfico.");
+  } catch (error) {
+    console.log(error);
+    return new Error(
+      (error as { message?: string })?.message || "Erro ao buscar a série do gráfico."
+    );
+  }
+};

--- a/app/tests/pages/home.test.tsx
+++ b/app/tests/pages/home.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import React from "react";
 import Home from "~/pages/home/home";
 import { renderWithProviders } from "../helpers/renderWithProviders";
@@ -8,24 +9,201 @@ vi.mock("~/routes", () => ({
   optionsSideMenu: vi.fn(),
 }));
 
+vi.mock("~/shared/services/api/dashboard/get-resumo", () => ({
+  getDashboardResumo: vi.fn(),
+}));
+
+vi.mock("~/shared/services/api/dashboard/get-serie", () => ({
+  getDashboardSerie: vi.fn(),
+}));
+
+vi.mock("~/shared/services/api/dashboard/get-anos-disponiveis", () => ({
+  getAnosDisponiveis: vi.fn(),
+}));
+
+import { getDashboardResumo } from "~/shared/services/api/dashboard/get-resumo";
+import { getDashboardSerie } from "~/shared/services/api/dashboard/get-serie";
+import { getAnosDisponiveis } from "~/shared/services/api/dashboard/get-anos-disponiveis";
+
+const mockGetDashboardResumo = vi.mocked(getDashboardResumo);
+const mockGetDashboardSerie = vi.mocked(getDashboardSerie);
+const mockGetAnosDisponiveis = vi.mocked(getAnosDisponiveis);
+
+const resumoPositivo = {
+  saldoAtual: 1500,
+  maiorCategoriaGasto: "Moradia",
+  maiorCategoriaValor: 1200,
+  saudeFinanceiraPercentual: 30,
+  saudeFinanceiraStatus: "Saudável",
+};
+
+const serieMensal = [
+  { periodo: new Date("2026-07-01"), receita: 5000, despesa: 4000, saldo: 1000 },
+  { periodo: new Date("2026-08-01"), receita: 5000, despesa: 3500, saldo: 1500 },
+];
+
 describe("Home page", () => {
-  it("deve renderizar sem erros", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetDashboardSerie.mockResolvedValue(serieMensal);
+    mockGetAnosDisponiveis.mockResolvedValue([2024, 2025, 2026]);
+  });
+
+  it("deve renderizar sem erros", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
     renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(mockGetDashboardResumo).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("deve exibir o título 'Página inicial'", () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
     renderWithProviders(<Home />);
     expect(screen.getByText("Página inicial")).toBeInTheDocument();
   });
 
   it("deve renderizar o gráfico de linha", () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
     const { container } = renderWithProviders(<Home />);
     expect(container.querySelector("svg")).toBeInTheDocument();
   });
 
-  it("deve renderizar a imagem de saldo positivo", () => {
+  it("deve buscar a série com o período 'mes' por padrão, sem ano/mês selecionados", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
     renderWithProviders(<Home />);
-    const img = screen.getByAltText("Saldo positivo");
-    expect(img).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockGetDashboardSerie).toHaveBeenCalledWith(1, {
+        periodo: "mes",
+        ano: undefined,
+        mes: undefined,
+      });
+    });
+  });
+
+  it("deve exibir o saldo atual formatado quando a API responde", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/R\$\s*1\.500,00/i)).toBeInTheDocument();
+    });
+  });
+
+  it("deve exibir a imagem de saldo positivo quando o saldo é >= 0", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("Saldo positivo")).toBeInTheDocument();
+    });
+  });
+
+  it("deve exibir a imagem de saldo negativo quando o saldo é < 0", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce({
+      ...resumoPositivo,
+      saldoAtual: -500,
+      saudeFinanceiraStatus: "Crítico",
+    });
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByAltText("Saldo negativo")).toBeInTheDocument();
+    });
+  });
+
+  it("deve exibir a categoria de maior gasto", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Moradia")).toBeInTheDocument();
+    });
+  });
+
+  it("deve tratar erro da API sem quebrar a UI", async () => {
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    mockGetDashboardResumo.mockResolvedValueOnce(new Error("Falha ao buscar resumo"));
+
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith("Falha ao buscar resumo");
+    });
+
+    alertSpy.mockRestore();
+  });
+
+  it("deve exibir os 3 filtros de período com 'Mês' selecionado por padrão", () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
+    renderWithProviders(<Home />);
+
+    expect(screen.getByRole("button", { name: "Semana" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Ano" })).toBeInTheDocument();
+
+    const botaoMes = screen.getByRole("button", { name: "Mês" });
+    expect(botaoMes).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("deve rebuscar a série ao clicar no filtro 'Ano'", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(mockGetDashboardSerie).toHaveBeenCalledWith(1, { periodo: "mes", ano: undefined, mes: undefined });
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Ano" }));
+
+    await waitFor(() => {
+      expect(mockGetDashboardSerie).toHaveBeenCalledWith(1, { periodo: "ano", ano: undefined, mes: undefined });
+    });
+  });
+
+  it("deve mostrar o seletor de ano no filtro 'Mês' e rebuscar ao escolher um ano", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
+    renderWithProviders(<Home />);
+
+    await waitFor(() => {
+      expect(mockGetDashboardSerie).toHaveBeenCalledWith(1, { periodo: "mes", ano: undefined, mes: undefined });
+    });
+
+    await userEvent.click(screen.getByText("Últimos 12 meses"));
+    await userEvent.click(await screen.findByRole("option", { name: "2025" }));
+
+    await waitFor(() => {
+      expect(mockGetDashboardSerie).toHaveBeenCalledWith(1, { periodo: "mes", ano: 2025, mes: undefined });
+    });
+  });
+
+  it("deve mostrar seletor de mês desabilitado no filtro 'Semana' até um ano ser escolhido", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
+    renderWithProviders(<Home />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Semana" }));
+
+    const [, selectMes] = screen.getAllByRole("combobox");
+    expect(selectMes).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("deve rebuscar a série com ano e mês ao selecionar ambos no filtro 'Semana'", async () => {
+    mockGetDashboardResumo.mockResolvedValueOnce(resumoPositivo);
+    renderWithProviders(<Home />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Semana" }));
+
+    const [selectAno] = screen.getAllByRole("combobox");
+    await userEvent.click(selectAno);
+    await userEvent.click(await screen.findByRole("option", { name: "2026" }));
+
+    const [, selectMes] = screen.getAllByRole("combobox");
+    await userEvent.click(selectMes);
+    await userEvent.click(await screen.findByRole("option", { name: "Agosto" }));
+
+    await waitFor(() => {
+      expect(mockGetDashboardSerie).toHaveBeenCalledWith(1, { periodo: "semana", ano: 2026, mes: 8 });
+    });
   });
 });


### PR DESCRIPTION
## O que muda

`home.tsx` (dashboard/página inicial) ganha:

- **Cards reais** de Saldo Atual, Saúde Financeira e Maior Categoria de Gasto (consumindo `GET /Dashboard/resumo`).
- **Gráfico com 3 filtros** (`Ano` / `Mês` / `Semana`, "Mês" selecionado por padrão), cada um pedindo os dados de `GET /Dashboard/serie` de novo ao trocar:
  - **Ano**: seletor "Todos os anos" (comparação multi-ano, padrão) ou um ano específico.
  - **Mês**: seletor "Últimos 12 meses" (padrão) ou um ano específico (mostra jan–dez daquele ano).
  - **Semana**: seletores de Ano + Mês (Mês desabilitado até escolher o ano); sem seleção, mostra as últimas 4 semanas mais atuais.
- Lista de anos disponíveis pros seletores vem de `GET /Dashboard/anos-disponiveis`.
- A imagem circular volta a trocar entre "feliz"/"triste" dependendo do saldo (antes só usava a versão positiva).

Depende da PR equivalente no back-end: [controle-financeiro-api#5](https://github.com/GabrielBarbosaGomes/controle-financeiro-api/pull/5).

## Testes

206/206 passando (14 em `home.test.tsx`, cobrindo os 3 filtros e a interação com os seletores de ano/mês).

## Test plan

- [x] `npm run typecheck` sem novos erros.
- [x] `npx vitest run` — 206/206 passando.
- [x] Testado em tela via Playwright contra a API real: os 3 filtros, seletor de ano no modo Ano, seletor de ano no modo Mês, seletores de ano+mês no modo Semana (incluindo o caso de borda mês-anterior/mês-atual).